### PR TITLE
fix subquery select

### DIFF
--- a/migrations/2022-08-18-115412_add-collections-last-modified-to-settings/up.sql
+++ b/migrations/2022-08-18-115412_add-collections-last-modified-to-settings/up.sql
@@ -11,7 +11,8 @@ INTO settings(user_id, collections_last_modified_time)
     (SELECT COLLECTION_LAST_MODIFIED_USER.user_id, COLLECTION_LAST_MODIFIED_USER.modified_time
      from COLLECTION_LAST_MODIFIED_USER)
 ON CONFLICT(user_id) DO UPDATE SET collections_last_modified_time = (SELECT COLLECTION_LAST_MODIFIED_USER.modified_time
-                                                                     from COLLECTION_LAST_MODIFIED_USER);
+                                                                     from COLLECTION_LAST_MODIFIED_USER
+                                                                     where user_id = EXCLUDED.user_id);
 
 -- Trigger and function to update collection_items + default collections when old API is used.
 CREATE OR REPLACE FUNCTION update_last_modified()


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed

## Summary by Sourcery

Bug Fixes:
- Fix subquery in SQL migration to correctly update collections_last_modified_time only for the conflicting user_id.